### PR TITLE
Add ability to build on macOS

### DIFF
--- a/make_highsmex.m
+++ b/make_highsmex.m
@@ -5,18 +5,16 @@
 %% Inputs
 
 if ismac
-    % Path to the HiGHS library include directory
-    highsIncludeDir = '/opt/homebrew/include/highs/';
-
-    % Path to folder containing the HiGHS static library
-    highsLibIncludeDir = '/opt/homebrew/lib';
+    highsInstallDir = '/opt/homebrew';
 else
-    % Path to the HiGHS library include directory
-    highsIncludeDir = '.\HiGHS-1.10.0\installcpp20\include\highs';
-
-    % Path to folder containing the HiGHS static library
-    highsLibIncludeDir = '.\HiGHS-1.10.0\installcpp20\lib';
+    highsInstallDir = '.\HiGHS-1.10.0\installcpp20';
 end
+
+% Path to the HiGHS library include directory
+highsIncludeDir = fullfile(highsInstallDir, 'include', 'highs');
+
+% Path to folder containing the HiGHS static library
+highsLibIncludeDir = fullfile(highsInstallDir, 'lib');
 
 % Path to the highsmex.cpp file
 mexSrcFilePath = fullfile('.', 'highsmex.cpp');

--- a/make_highsmex.m
+++ b/make_highsmex.m
@@ -4,14 +4,22 @@
 
 %% Inputs
 
-% Path to the HiGHS library include directory
-highsIncludeDir = '.\HiGHS-1.10.0\installcpp20\include\highs';
+if ismac
+    % Path to the HiGHS library include directory
+    highsIncludeDir = '/opt/homebrew/include/highs/';
 
-% Path to folder containing the HiGHS static library
-highsLibIncludeDir = '.\HiGHS-1.10.0\installcpp20\lib';
+    % Path to folder containing the HiGHS static library
+    highsLibIncludeDir = '/opt/homebrew/lib';
+else
+    % Path to the HiGHS library include directory
+    highsIncludeDir = '.\HiGHS-1.10.0\installcpp20\include\highs';
+
+    % Path to folder containing the HiGHS static library
+    highsLibIncludeDir = '.\HiGHS-1.10.0\installcpp20\lib';
+end
 
 % Path to the highsmex.cpp file
-mexSrcFilePath = '.\highsmex.cpp';
+mexSrcFilePath = fullfile('.', 'highsmex.cpp');
 
 %% Build mex file
 
@@ -23,6 +31,9 @@ switch compilerVendor
 
     case 'gnu'
         compflags='CXXFLAGS=''$CXXFLAGS  -std=c++20  -Wall ''';
+
+    case 'apple'
+        compflags='CXXFLAGS="$CXXFLAGS -std=c++20 -mmacosx-version-min=13.4 "';
 end
 
 mex(mexSrcFilePath, '-R2018a', sprintf('-I"%s"', highsIncludeDir), sprintf('-L"%s"', highsLibIncludeDir), '-lhighs', '-v', compflags)


### PR DESCRIPTION
Tested with MATLAB R2025a on macOS Sequoia 15.4.1 on 2023 MBP with M2 Max processor and HiGHS 1.10.0 installed via HomeBrew.

Let me know if you want to include the `highsmex.mexmaca64` file here (or in a separate PR).

Since the only HiGHS files I see in `/opt/homebrew/lib` are `.dylib` files, I assume my current MEX would require someone to install HiGHS via HomeBrew first for it to work for them. I can try to build one that has HiGHS statically linked into the MEX _(as I assume your Windows version does)_, if you would prefer that.
