### PR TITLE
Fix warning about no semi-integer/integer variables

### DIFF
--- a/highsmex.cpp
+++ b/highsmex.cpp
@@ -1021,7 +1021,7 @@ class MexFunction : public Function {
 		}
 
 		if (setToDefault) {
-			highsModel.lp_.integrality_.assign(highsModel.lp_.num_col_, HighsVarType::kContinuous);
+			highsModel.lp_.integrality_ = {};
 		}
 		else {
 			const TypedArray<MATLABString> integralityStrings(inputs[7]);


### PR DESCRIPTION
When the `output_flag` option is true for LP and QP problems, I'm seeing a lot of these warnings ...
```
Warning: in mex function highsmex: WARNING: No semi-integer/integer variables in model with non-empty integrality


> In callhighs (line 136)
```

Not 100% certain this is the correct fix, but it seems to work.