### PR TITLE
Use in-process MEX call for compiled MATLAB context

### DIFF
--- a/callhighs.m
+++ b/callhighs.m
@@ -144,22 +144,26 @@ function varargout = callhighs(varargin)
 
 persistent mh
 
-if ~(isa(mh, "matlab.mex.MexHost") && isvalid(mh))
-    mh = mexhost;
+useMexHostByDefault = true;
+% useMexHostByDefault = false;
+
+if nargin>1 && issparse(varargin{2})
+    varargin{2} = sparseMatrixToCell(varargin{2});
+end
+if nargin>6 && issparse(varargin{7})
+    varargin{7} = sparseMatrixToCell(varargin{7});
 end
 
-if nargin>1
-    if issparse(varargin{2})
-        varargin{2} = sparseMatrixToCell(varargin{2});
+if useMexHostByDefault && ~isdeployed
+    %% OUT-OF-PROCESS (desktop MATLAB only)
+    if ~(isa(mh, "matlab.mex.MexHost") && isvalid(mh))
+        mh = mexhost;
     end
+    [varargout{1:nargout}] = feval(mh, "highsmex", varargin{:});
+else
+    %% IN-PROCESS (for compiled MATLAB code)
+    [varargout{1:nargout}] = highsmex(varargin{:});
 end
-if nargin>6
-    if issparse(varargin{7})
-        varargin{7} = sparseMatrixToCell(varargin{7});
-    end
-end
-
-[varargout{1:nargout}] = feval(mh, "highsmex", varargin{:});
 
 % ----------------------------------------------------------------------- %
 


### PR DESCRIPTION
It turns out the MATLAB Compiler does not support out-of-process calls to MEX files, only in-process.

With this PR, `callhighs()` uses `is_deployed()` to decide whether to use in-process or out-of-process call to `highsmex()`, allowing HiGHSMEX to be included in a compiled MATLAB program.

Also, it is now trivial to use an in-process MEX call in desktop MATLAB by uncommenting the `useMexHostByDefault = false` line.

FWIW, in my testing the out-of-process call can add some non-trivial overhead. With some code I have that calls HiGHS repeatedly to solve lots of LP and MILP problems, I observed runtime improvements on the order of 7-30% just by switching to in-process.

I'm curious what your reasons were for choosing to use the out-of-process approach?

Actually, it might be nice to have both approaches available. What do you think of including something like a separate `callhighs_in_process()` wrapper that always uses the in-process MEX call.