### PR TITLE
Add manually triggered GitHub workflow to build MEX files

### DIFF
--- a/.github/actions/build-highsmex/action.yml
+++ b/.github/actions/build-highsmex/action.yml
@@ -1,0 +1,96 @@
+name: Build HiGHSMEX
+description: Common build steps for all platforms
+
+inputs:
+  highs_version:
+    description: "HiGHS version to use for MEX build"
+    required: true
+    default: "1.15.1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: HiGHS archive name (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        highs_dir_name="highs-${{ inputs.highs_version }}-arm-apple-static-apache"
+        echo "HIGHS_DIR_NAME=${highs_dir_name}" >> $GITHUB_ENV
+        echo "HIGHS_ARCHIVE_NAME=${highs_dir_name}.tar.gz" >> $GITHUB_ENV
+
+    - name: HiGHS archive name (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        highs_dir_name="highs-${{ inputs.highs_version }}-x86_64-windows-static-apache"
+        echo "HIGHS_DIR_NAME=${highs_dir_name}" >> $GITHUB_ENV
+        echo "HIGHS_ARCHIVE_NAME=${highs_dir_name}.zip" >> $GITHUB_ENV
+
+    - name: Set up MATLAB
+      uses: matlab-actions/setup-matlab@v2
+
+    - name: Configure MATLAB
+      uses: MATPOWER/action-configure-matlab@v3-test
+
+    - name: Download & extract HiGHS ${{ inputs.highs_version }}
+      shell: bash
+      run: |
+        url="https://github.com/ERGO-Code/HiGHS/releases/download/v${{ inputs.highs_version }}/${HIGHS_ARCHIVE_NAME}"
+        parent="$(dirname "${{ github.workspace }}")"
+        echo "Parent: $parent"
+
+        archive="${parent}/${HIGHS_ARCHIVE_NAME}"
+
+        echo "Downloading: $url"
+        curl -L -o "$archive" "$url"
+        dest="${parent}/${HIGHS_DIR_NAME}"
+
+        echo "Extracting: $archive"
+        echo "      into: $dest"
+        mkdir -p "$dest"
+        if [[ "$HIGHS_ARCHIVE_NAME" == *.tar.gz ]]; then
+          tar -xzf "$archive" -C "$dest"
+        else
+          unzip -o "$archive" -d "$dest"
+        fi
+
+        echo "Parent dir listing:"
+        ls -al ..
+
+        echo "HiGHS dir: ${HIGHS_DIR_NAME}"
+        ls -al "$dest"
+        find "$dest" -maxdepth 2 -type d -print
+
+    - name: List MEX files (before)
+      shell: bash
+      run: |
+        echo "repo root MEX files"
+        ls -al *.mex* || true
+
+    - name: Build MEX
+      shell: bash
+      run: |
+        $ML_CMD "ver; cd '${{ github.workspace }}'; make_highsmex('${{ inputs.highs_version }}')"
+
+    - name: List MEX files (after)
+      shell: bash
+      run: |
+        ls -al *.mex* || true
+
+    - name: Check MEX functionality
+      shell: bash
+      run: |
+        $ML_CMD "fprintf('HiGHS Version: %s\nHiGHSMEX Version: %s\n', callhighs(string('ver')), verHiGHSMEX)"
+        $ML_CMD "c = [1;1]; soln=callhighs(c, c', 2, 2, c, c);"
+
+    - uses: actions/upload-artifact@v4
+      if: runner.os == 'macOS'
+      with:
+        name: highsmex.mexmaca64
+        path: highsmex.mexmaca64
+
+    - uses: actions/upload-artifact@v4
+      if: runner.os == 'Windows'
+      with:
+        name: highsmex.mexw64
+        path: highsmex.mexw64

--- a/.github/actions/build-highsmex/action.yml
+++ b/.github/actions/build-highsmex/action.yml
@@ -10,6 +10,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: HiGHS archive name (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        highs_dir_name="highs-${{ inputs.highs_version }}-x86_64-linux-gnu-static-apache"
+        echo "HIGHS_DIR_NAME=${highs_dir_name}" >> $GITHUB_ENV
+        echo "HIGHS_ARCHIVE_NAME=${highs_dir_name}.tar.gz" >> $GITHUB_ENV
+
     - name: HiGHS archive name (macOS)
       if: runner.os == 'macOS'
       shell: bash
@@ -78,10 +86,17 @@ runs:
         ls -al *.mex* || true
 
     - name: Check MEX functionality
+      if: runner.os != 'Linux'
       shell: bash
       run: |
         $ML_CMD "fprintf('HiGHS Version: %s\nHiGHSMEX Version: %s\n', callhighs(string('ver')), verHiGHSMEX)"
         $ML_CMD "c = [1;1]; soln=callhighs(c, c', 2, 2, c, c);"
+
+    - uses: actions/upload-artifact@v4
+      if: runner.os == 'Linux'
+      with:
+        name: highsmex.mexa64
+        path: highsmex.mexa64
 
     - uses: actions/upload-artifact@v4
       if: runner.os == 'macOS'

--- a/.github/actions/build-highsmex/action.yml
+++ b/.github/actions/build-highsmex/action.yml
@@ -34,6 +34,12 @@ runs:
         echo "HIGHS_DIR_NAME=${highs_dir_name}" >> $GITHUB_ENV
         echo "HIGHS_ARCHIVE_NAME=${highs_dir_name}.zip" >> $GITHUB_ENV
 
+    - name: Preload System libstdc++ (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6" >> $GITHUB_ENV
+
     - name: Set up MATLAB
       uses: matlab-actions/setup-matlab@v2
 
@@ -86,7 +92,6 @@ runs:
         ls -al *.mex* || true
 
     - name: Check MEX functionality
-      if: runner.os != 'Linux'
       shell: bash
       run: |
         $ML_CMD "fprintf('HiGHS Version: %s\nHiGHSMEX Version: %s\n', callhighs(string('ver')), verHiGHSMEX)"

--- a/.github/workflows/manual-mex-build.yml
+++ b/.github/workflows/manual-mex-build.yml
@@ -7,6 +7,10 @@ on:
         description: "HiGHS version to use for MEX build"
         required: true
         default: "1.15.1"
+      build_linux:
+        required: true
+        type: boolean
+        default: false
       build_macos:
         required: true
         type: boolean
@@ -17,6 +21,17 @@ on:
         default: true
 
 jobs:
+  build_linux:
+    if: ${{ inputs.build_linux }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Build Linux MEX file with HiGHS ${{ inputs.highs_version }}
+        uses: ./.github/actions/build-highsmex
+        with:
+          highs_version: ${{ inputs.highs_version }}
+
   build_macos:
     if: ${{ inputs.build_macos }}
     runs-on: macos-latest

--- a/.github/workflows/manual-mex-build.yml
+++ b/.github/workflows/manual-mex-build.yml
@@ -1,0 +1,40 @@
+name: Build HiGHSMEX
+
+on:
+  workflow_dispatch:
+    inputs:
+      highs_version:
+        description: "HiGHS version to use for MEX build"
+        required: true
+        default: "1.15.1"
+      build_macos:
+        required: true
+        type: boolean
+        default: true
+      build_windows:
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  build_macos:
+    if: ${{ inputs.build_macos }}
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Build macOS MEX file with HiGHS ${{ inputs.highs_version }}
+        uses: ./.github/actions/build-highsmex
+        with:
+          highs_version: ${{ inputs.highs_version }}
+
+  build_windows:
+    if: ${{ inputs.build_windows }}
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Build Windows MEX file with HiGHS ${{ inputs.highs_version }}
+        uses: ./.github/actions/build-highsmex
+        with:
+          highs_version: ${{ inputs.highs_version }}

--- a/.github/workflows/manual-mex-build.yml
+++ b/.github/workflows/manual-mex-build.yml
@@ -10,7 +10,7 @@ on:
       build_linux:
         required: true
         type: boolean
-        default: false
+        default: true
       build_macos:
         required: true
         type: boolean

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+untracked

--- a/highsmex.cpp
+++ b/highsmex.cpp
@@ -45,7 +45,7 @@ enum class MexCallSyntax { kVer, kDefaultOpts, kIntType, kSolve };
 
 // Compile time constants
 constexpr ArrayType   HighsInt2MatlabArrayType = std::is_same_v<HighsInt, int32_t> ? ArrayType::INT32 : ArrayType::INT64;
-constexpr std::string HighsInt2MatlabClassStr = std::is_same_v<HighsInt, int32_t> ? "int32" : "int64";
+const std::string HighsInt2MatlabClassStr = std::is_same_v<HighsInt, int32_t> ? "int32" : "int64";
 constexpr bool        MexDebugPrinting = 0;
 
 // Const variables
@@ -154,7 +154,7 @@ bool isEqualFieldnames(const std::vector<std::string>& f1, const std::vector<std
 	if (f1.size() != f2.size()) return false;
 	const std::set<std::string> f2set(f2.begin(), f2.end());
 	for (auto const& s : f1) {
-		if (!f2set.contains(s)) return false;
+		if (f2set.find(s) == f2set.end()) return false;
 	}
 	return true;
 }

--- a/make_highsmex.m
+++ b/make_highsmex.m
@@ -1,54 +1,72 @@
-% This script builds the highsmex.cpp file
+function make_highsmex(highs_ver)
+% This function builds the MEX file.
 %
 % Author: Savyasachi Singh
+% Modified by: Ray Zimmerman
 %
 % Covered by the MIT License (see LICENSE file for details).
 % See https://github.com/savyasachi/HiGHSMEX for more information.
 
 %% Inputs
-
-% link static file distributed by the HiGHS which includes the HiPO solver
-if ispc
-    highsInstallDir = fullfile('.', 'highs-1.15.1-x86_64-windows-static-apache');
-elseif ismac
-    highsInstallDir = fullfile('..', 'highs-1.15.1-arm-apple-static-apache');
-else
-    disp('highsInstallDir variable not defined in make_highsmex.m');
+if nargin < 1
+    highs_ver = '1.15.1';
 end
-% highsInstallDir = fullfile('.', 'HiGHS-1.13.1', 'installcpp20'); % link static file built from source
 
-% Path to the HiGHS library include directory
+% Path to HiGHS official binary HiGHS distribution, including HiPO solver.
+% Extract archive beside HiGHSMEX repo.
+if ispc
+    arch = 'x86_64-windows';        % Windows
+elseif ismac
+    arch =  'arm-apple';            % macOX
+elseif isunix
+    arch =  'x86_64-linux-gnu';     % Linux
+end
+highsInstallDir = fullfile('..', ...
+    sprintf('highs-%s-%s-static-apache', highs_ver, arch));
+
+%% Paths to HiGHS include & lib dirs and HIGHSMEX source file
 highsIncludeDir = fullfile(highsInstallDir, 'include', 'highs');
-
-% Path to folder containing the HiGHS static library
-highsLibIncludeDir = fullfile(highsInstallDir, 'lib');
-
-% Path to the highsmex.cpp file
+highsLibDir = fullfile(highsInstallDir, 'lib');
 mexSrcFilePath = fullfile('.', 'highsmex.cpp');
 
-%% Build mex file
-
+%% Platform specific compiler, linker flags
 compilerInfo=mex.getCompilerConfigurations('C++', 'Selected');
 compilerVendor=lower(compilerInfo.Manufacturer);
 switch compilerVendor
     case 'microsoft'
-        compflags={ 'COMPFLAGS="$COMPFLAGS  /std:c++20  /W3 "' };
-
-    case 'gnu'
-        compflags={ 'CXXFLAGS=''$CXXFLAGS  -std=c++20  -Wall ''' };
-
+        compflags = {
+            '-lopenblas', '-v', ...
+            'COMPFLAGS="$COMPFLAGS /std:c++20  /W3 "', ...
+        };
     case 'apple'
-        compflags={ 'CXXFLAGS="$CXXFLAGS -std=c++20 -mmacosx-version-min=13.4 "', ...
-            'LDFLAGS="$LDFLAGS -mmacosx-version-min=13.4 "' };
+        compflags = { '-lz', '-v',
+            'CXXFLAGS="$CXXFLAGS -std=c++20 -mmacosx-version-min=13.4 "', ...
+            'LDFLAGS="$LDFLAGS -mmacosx-version-min=13.4 -Wl,-framework,Accelerate"', ...
+        };
+    case 'gnu'
+        compflags = {
+            '-lopenblas', '-lz', '-v', ...
+            'COMPFLAGS="$COMPFLAGS -std=c++20 -Wall"', ...
+            'LDFLAGS="$LDFLAGS -static-libstdc++ -static-libgcc"', ...
+        };
+end
+if vstr2num(highs_ver) > 1.015
+    compflags = {'-lhighs_extras', compflags{:}};
 end
 
-% mex(mexSrcFilePath, '-R2018a', sprintf('-I"%s"', highsIncludeDir), sprintf('-L"%s"', highsLibIncludeDir), '-lhighs', '-v', compflags{:})
-if ispc
-    mex(mexSrcFilePath, '-R2018a', sprintf('-I"%s"', highsIncludeDir), sprintf('-L"%s"', highsLibIncludeDir), '-lhighs', '-lhighs_extras', '-lopenblas', '-v', compflags{:})
-elseif ismac
-    mex(mexSrcFilePath, '-R2018a', sprintf('-I"%s"', highsIncludeDir), sprintf('-L"%s"', highsLibIncludeDir), '-lhighs', '-lhighs_extras', '-lz', ['LDFLAGS=$LDFLAGS -Wl,-framework,Accelerate'], '-v', compflags{:})
-else
-    disp('Inputs to mex command not defined in make_highsmex.m');
-end
+%% Build mex file
+mex(mexSrcFilePath, '-R2018a', sprintf('-I"%s"', highsIncludeDir), ...
+    sprintf('-L"%s"', highsLibDir), '-lhighs', compflags{:});
 
-% EOF
+
+function num = vstr2num(vstr)
+% Converts version string to numerical value suitable for < or > comparisons
+% E.g. '1.15.1' -->  1.015001
+pat = '\.?(\d+)';
+[s,e,tE,m,t] = regexp(vstr, pat);
+b = 1;
+num = 0;
+for k = 1:length(t)
+    num = num + b * str2num(t{k}{1});
+    b = b / 1000;
+end


### PR DESCRIPTION
With this workflow added to the default branch, you should see a "Run workflow" button under the Actions tab.

<img width="328" height="388" alt="Screenshot 2026-07-20 at 3 11 47 PM" src="https://github.com/user-attachments/assets/8df5a2f3-485b-49ed-8fa7-6e0d4149b7d7" />

It is a manually triggered workflow at the moment, so no automatic building on push or anything. By default it builds macOS and Windows MEX files from the selected branch, and uploads the MEX files as build artifacts to the workflow Summary page when finished.

<img width="920" height="266" alt="Screenshot 2026-07-20 at 3 13 17 PM" src="https://github.com/user-attachments/assets/a355f11e-2de9-4a98-a9c5-73e180f72de1" />

You can also select to build a Linux MEX file. It should build fine, but MATLAB gives a runtime error that I'm hoping the HiGHS team may be willing to help address (see https://github.com/ERGO-Code/HiGHS/issues/3154). We can enable it by default once we get it building a usable MEX file.

We should be able to also make it automatically commit the successfully built MEX file to the repo on the same branch, but I figured leaving that as a manual step for now keeps things simpler.