### PR TITLE
Disable direct HiGHS console output

### DIFF
--- a/highsmex.cpp
+++ b/highsmex.cpp
@@ -1481,6 +1481,7 @@ class MexFunction : public Function {
 			checkHighsReturnStatus(highs.startCallback(HighsCallbackType::kCallbackLogging),
 				"Warning issued when attempting to start the logging callback.",
 				"Failed to start the logging callback.");
+			highs.setOptionValue("log_to_console", false);
 		}
 
 		// Pass constraints and hessian to HiGHS


### PR DESCRIPTION
I realized there were 2 issues with console output and #54 only addressed one of them.

It turns out that log output was being sent

1. directly to STDOUT by HiGHS itself, **and** 
2. to the Matlab console by the log callback in HiGHSMEX.

When running in the MATLAB GUI, typically 1 is invisible and 2 is what you see in the MATLAB Command Window. Issue #53,  addressed by PR #54, was that setting the `log_to_console` option to false was not turning off 2, so the output was still visible.

The second issue however, is that 1 is not _always_ invisible, so sometimes you see duplicate output of everything, such as when running a batch job from the command line (as in the Build HiGHSMEX workflow on GitHub), or when launching MATLAB (with or without the GUI) from a macOS or Linux terminal.

This PR addresses this second issue by relying entirely on the log callback for output. That is, it uses the `log_to_console` passed in to determine whether or not to register the callback, then it **always** passes a false value for the `log_to_console` option to the solver.

This should eliminate 1 completely, keeping HiGHS from ever writing directly to STDOUT, and thus eliminating any duplicate output. It appears to work as expected in my testing.